### PR TITLE
Add examples for Google Keep/Calendar

### DIFF
--- a/Examples/google_calendar.json
+++ b/Examples/google_calendar.json
@@ -1,7 +1,7 @@
 {
   "tabs": [
     {
-      "title": "Calendar",
+      "title": "Google Calendar",
       "url": "https://calendar.google.com/calendar/u/0/r",
       "customJs": [
         "https://gist.github.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js"

--- a/Examples/google_calendar.json
+++ b/Examples/google_calendar.json
@@ -1,0 +1,11 @@
+{
+  "tabs": [
+    {
+      "title": "Calendar",
+      "url": "https://calendar.google.com/calendar/u/0/r",
+      "customJs": [
+        "https://gist.github.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js"
+      ]
+    }
+  ]
+}

--- a/Examples/google_keep.json
+++ b/Examples/google_keep.json
@@ -1,0 +1,11 @@
+{
+  "tabs": [
+    {
+      "title": "Google Keep",
+      "url": "https://keep.google.com/#home",
+      "customJs": [
+        "https://gist.github.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds example JSON configs for Google Keep/Calendar. Both link to https://gist.githubusercontent.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js, which is a combination of the fix for links with Gmail/Calendar and the find in page support - happy to remove if we don't think it'd be a good example (or otherwise host in the multi repo).