### PR TITLE
Add Gmail Example

### DIFF
--- a/Examples/gmail.json
+++ b/Examples/gmail.json
@@ -1,0 +1,12 @@
+{
+  "tabs": [
+    {
+      "title": "Gmail",
+      "url": "https://mail.google.com/mail/u/0/",
+      "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.2 Safari/605.1.15",
+      "customJs": [
+        "https://gist.github.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Updates the examples folder to add one for Gmail. Uses a link to https://gist.githubusercontent.com/clinejj/ca02dbb6a811aec1cc433c97cae45d69/raw/a538a0108e8f0c2498a8a9a7782c55f281e1f5cf/multi_google.js, which is a combination of the fix for links with Gmail/Calendar and the find in page support - happy to remove if we don't think it'd be a good example (or otherwise host in the multi repo). It's used in the existing Keep/Calendar examples as well.